### PR TITLE
#5 feat(main): 할 일 목록 페이지(홈페이지) 구현

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,30 +1,33 @@
 "use client";
-
-import Button from "@/components/common/Button";
 import Header from "@/components/common/Header";
-import Checkbox from "@/components/common/CheckBox";
-import Search from "@/components/common/Search";
-import Memo from "@/components/common/Memo";
+import useTodos from "@/hooks/useTodos";
+import {useEffect} from "react";
+import TodoForm from "@/components/todo/TodoForm";
+import TodoList from "@/components/todo/TodoList";
 
 export default function Home() {
 
+    const {todos, todoList, doneList, fetchTodos, addTodo} = useTodos();
+
+    useEffect(() => {
+        fetchTodos();
+    }, [fetchTodos]);
+
     return (
-        <>
+        <div className="min-h-screen bg-gray-50 pb-20">
             <Header/>
-            <div className="flex items-center justify-center bg-slate-100 gap-4">
-                <Button variant="add" onClick={() => console.log('추가 클릭')}/>
-                <Button variant="delete" onClick={() => console.log('삭제 클릭')}/>
-                <Button variant="complete" onClick={() => console.log('완료 클릭')}/>
-            </div>
-            <Checkbox variant="list" isCompleted={false} text="비타민 챙겨 먹기" onToggle={() => console.log("토글")}/>
-            <Checkbox variant="detail" isCompleted={true} text="비타민 챙겨 먹기" onToggle={() => console.log("토글")}/>
-            <Search onChange={() => console.log("변화")} value={""}/>
-            <Memo
-                value={"메모"}
-                onChange={() => console.log("변화")}
-                placeholder="메모를 입력해주세요."
-            />
-            {/*<ImageUpload imageUrl={"imageUrl"} onImageChange={() => console.log("이미지 추가")}/>*/}
-        </>
+            <main className="max-w-7xl mx-auto px-4 md:px-6 mt-6 md:mt-10 flex flex-col gap-10">
+                {/* 폼 영역 */}
+                <TodoForm onAdd={addTodo} hasTodos={todos.length > 0}/>
+
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-6">
+                    {/* 할 일 목록 (TODO) */}
+                    <TodoList title="TODO" items={todoList}/>
+
+                    {/* 완료된 목록 (DONE) */}
+                    <TodoList title="DONE" items={doneList}/>
+                </div>
+            </main>
+        </div>
     );
 }

--- a/components/common/Input.tsx
+++ b/components/common/Input.tsx
@@ -5,24 +5,26 @@ export default function Input({
                                   value,
                                   onChange,
                                   placeholder = "할 일을 입력해주세요.",
+                                  onKeyDown
                               }: InputProps) {
     return (
         <div className="w-full h-14 relative">
             {/* Shadow */}
             <div
-                className="w-full h-[52.5px] absolute left-[3px] top-[2.5px] rounded-3xl bg-slate-900 border-2 border-slate-900"/>
+                className="w-full h-[52.5px] absolute left-0.75 top-[2.5px] rounded-3xl bg-slate-900 border-2 border-slate-900"/>
 
             {/* Background */}
             <div
-                className="w-full h-[52.5px] absolute left-[-1px] top-[-1px] rounded-3xl bg-slate-100 border-2 border-slate-900"/>
+                className="w-full h-[52.5px] absolute -left-px -top-px rounded-3xl bg-slate-100 border-2 border-slate-900"/>
 
             {/* Input */}
             <input
                 type="text"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
+                onKeyDown={onKeyDown}
                 placeholder={placeholder}
-                className="absolute left-[-1px] top-[-1px] w-full h-[52.5px] px-6 py-3 rounded-3xl bg-transparent border-2 border-transparent text-slate-900 text-base placeholder:text-slate-400 outline-none focus:border-slate-900 z-10"
+                className="absolute -left-px -top-px w-full h-[52.5px] px-6 py-3 rounded-3xl bg-transparent border-2 border-transparent text-slate-900 text-base placeholder:text-slate-400 outline-none focus:border-slate-900 z-10"
             />
         </div>
     );

--- a/components/todo/TodoForm.tsx
+++ b/components/todo/TodoForm.tsx
@@ -1,1 +1,50 @@
 /* 추가 폼 컴포넌트 */
+"use client";
+import {useState} from "react";
+import Input from "@/components/common/Input";
+import Button from "@/components/common/Button";
+import {TodoFormProps} from "@/lib/type";
+
+export default function TodoForm({onAdd, hasTodos}: TodoFormProps) {
+    const [inputValue, setInputValue] = useState("");
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const handleSubmit = async () => {
+        const trimmedValue = inputValue.trim();
+
+        if (!trimmedValue) {
+            alert("할 일을 입력해주세요.");
+            return;
+        }
+
+        setIsSubmitting(true);
+        const success = await onAdd(trimmedValue);
+        setIsSubmitting(false);
+
+        if (success) {
+            setInputValue("");
+        }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter" && !isSubmitting) {
+            handleSubmit();
+        }
+    };
+
+    return (
+        <div className="flex gap-2 md:gap-4 items-start w-full h-16">
+            <div className="grow">
+                <Input
+                    value={inputValue}
+                    onChange={setInputValue}
+                    onKeyDown={handleKeyDown}
+                    placeholder="할 일을 입력해주세요"
+                />
+            </div>
+            <div className="shrink-0">
+                <Button variant="add" onClick={handleSubmit} disabled={isSubmitting} hasTodos={hasTodos}/>
+            </div>
+        </div>
+    );
+}

--- a/components/todo/TodoList.tsx
+++ b/components/todo/TodoList.tsx
@@ -1,1 +1,92 @@
-/* 목록 렌더링 컴포넌트 */
+"use client";
+
+import Image from "next/image";
+import {TodoListProps} from "@/lib/type";
+
+const LIST_CONFIG = {
+    TODO: {
+        emptyImage: "/assets/img/Type=Todo, Size=Large.svg",
+        emptyText: "할 일이 없어요.",
+        emptySubText: "TODO를 새롭게 추가해주세요!",
+        tagBg: "bg-lime-300",
+        tagText: "text-green-700",
+    },
+    DONE: {
+        emptyImage: "/assets/img/Type=Done, Size=Large.svg",
+        emptyText: "아직 다 한 일이 없어요.",
+        emptySubText: "해야 할 일을 체크해보세요!",
+        tagBg: "bg-green-700",
+        tagText: "text-amber-300",
+    },
+} as const;
+
+export default function TodoList({title, items}: TodoListProps) {
+    const config = LIST_CONFIG[title];
+
+    return (
+        <section className="flex flex-col gap-4">
+            {/* 타이틀 태그 - config에서 색상을 가져옴 */}
+            <div className="w-fit">
+                <div
+                    className={`flex justify-center items-center gap-2.5 px-6.75 pt-1 pb-1.75 rounded-[23px] ${config.tagBg}`}>
+                    <p className={`text-lg font-bold text-center ${config.tagText}`}>
+                        {title}
+                    </p>
+                </div>
+            </div>
+
+            {/* 목록 영역 */}
+            {items.length > 0 ? (
+                <div className="flex flex-col gap-4">
+                    {items.map((item) => (
+                        <div
+                            key={item.id}
+                            className={`flex items-center gap-4 px-3 py-2.25 min-h-12.5 rounded-[27px] border-2 border-slate-900 ${
+                                item.isCompleted ? "bg-violet-100" : "bg-white"
+                            }`}
+                        >
+                            {/* 체크박스 로직 (생략 - 기존과 동일) */}
+                            <div className="shrink-0 cursor-pointer">
+                                {item.isCompleted ? (
+                                    <div
+                                        className="w-8 h-8 rounded-full bg-violet-600 flex items-center justify-center border-2 border-slate-900">
+                                        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                                            <path d="M4 8.14286L6.90909 11L12 6" stroke="#FEFCE8" strokeWidth="2.5"
+                                                  strokeLinecap="round" strokeLinejoin="round"/>
+                                        </svg>
+                                    </div>
+                                ) : (
+                                    <div className="w-8 h-8 rounded-full bg-yellow-50 border-2 border-slate-900"/>
+                                )}
+                            </div>
+
+                            <span
+                                className={`text-base font-medium truncate ${item.isCompleted ? "line-through text-slate-800" : "text-slate-800"}`}>
+                                {item.name}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            ) : (
+                /* Empty State - config의 값을 사용 */
+                <div className="flex flex-col items-center justify-center py-20 px-4 min-h-75">
+                    <Image
+                        src={config.emptyImage}
+                        alt="empty"
+                        width={240}
+                        height={240}
+                        className="w-48 h-48 md:w-60 md:h-60 mb-6 opacity-40"
+                    />
+                    <div className="text-center">
+                        <p className="text-slate-400 font-bold text-base">
+                            {config.emptyText}
+                        </p>
+                        <p className="text-slate-400 font-bold text-base">
+                            {config.emptySubText}
+                        </p>
+                    </div>
+                </div>
+            )}
+        </section>
+    );
+}

--- a/hooks/useTodos.ts
+++ b/hooks/useTodos.ts
@@ -1,1 +1,51 @@
-/* 목록 조회/추기/토글 훅 */
+/* 목록 조회 / 추가 / 토글 훅 */
+"use client";
+
+import {useCallback, useState} from "react";
+import {getItemResponse} from "@/lib/type";
+import {getItems, postItem} from "@/lib/api";
+
+export default function useTodos() {
+    const [todos, setTodos] = useState<getItemResponse[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+
+    // 할 일 목록 불러오기
+    const fetchTodos = useCallback(async () => {
+        try {
+            setIsLoading(true);
+            const data = await getItems();
+            setTodos(data);
+        } catch (err) {
+            console.error(err);
+            alert("할 일 목록을 불러오는 데 실패했습니다.");
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    // 할 일 추가
+    const addTodo = useCallback(async (name: string) => {
+        try {
+            const newTodo = await postItem({name});
+            setTodos((prev) => [newTodo, ...prev]);
+            return true;
+        } catch (err) {
+            console.error(err);
+            alert("할 일 추가에 실패했습니다.");
+            return false;
+        }
+    }, []);
+
+    const todoList = todos.filter((todo) => !todo.isCompleted);
+    const doneList = todos.filter((todo) => todo.isCompleted);
+
+    return {
+        todos,
+        todoList,
+        doneList,
+        isLoading,
+        fetchTodos,
+        addTodo,
+    };
+
+}

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -96,6 +96,7 @@ export interface InputProps {
     value: string;
     onChange: (value: string) => void;
     placeholder?: string;
+    onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
 export interface MemoProps {
@@ -121,4 +122,14 @@ export interface ButtonProps {
     disabled?: boolean;
     hasTodos?: boolean;
     isCompleted?: boolean;
+}
+
+export interface TodoListProps {
+    title: "TODO" | "DONE";
+    items: getItemResponse[];
+}
+
+export interface TodoFormProps {
+    onAdd: (name: string) => Promise<boolean>;
+    hasTodos: boolean;
 }


### PR DESCRIPTION
## 🛠️ 설명 (Description)

할 일의 유무에 따라 화면을 분기, 할 일 추가 및 목록 조회 기능을 `TodoForm`, `TodoList` 컴포넌트로 분리하여 역할을 명확히 했습니다.
또한 `useTodos` 커스텀 훅을 도입해, Todo 상태 관리 로직을 분리하였습니다.

공용 컴포넌트 역할을 명확히 하기 위해 `Search.tsx`를 `Input.tsx`로 수정했습니다.

## 📝 변경 사항 요약 (Summary)

- 할 일 없음 / 있음 상태에 따른 화면 분기 구성
- `TodoForm`, `TodoList` 컴포넌트 분리로 역할 명확화
- `useTodos` 훅을 통한 Todo 상태 관리 로직 분리
- `Search.tsx → Input.tsx` 파일명 변경
- 일부 Tailwind CSS 스타일 수정

## 🔗 관련 이슈 (Related Issues)

- Closed #5
- Related #None