### PR TITLE
#7 feat(detail): 상세 페이지 제목 편집 기능 추가

### DIFF
--- a/components/common/CheckBox.tsx
+++ b/components/common/CheckBox.tsx
@@ -12,7 +12,9 @@ export default function Checkbox({
                                      isCompleted,
                                      text,
                                      onToggle,
-                                     variant = "list"
+                                     variant = "list",
+                                     editable = false,
+                                     onTextChange
                                  }: CheckboxProps) {
 
     // varient 및 완료 상태에 따른 스타일 계산
@@ -39,7 +41,7 @@ export default function Checkbox({
         <div
             className={`w-full h-12.5 relative rounded-[27px] border-2 border-slate-900 ${bgColor}`}
         >
-            <div className={`flex items-center gap-4 ${containerClass}`}>
+            <div className={`flex items-center gap-4 ${containerClass} ml-2`}>
                 {/* 체크박스 아이콘 */}
                 <button
                     onClick={handleIconClick}
@@ -53,10 +55,20 @@ export default function Checkbox({
                     />
                 </button>
 
-                {/* 할 일 텍스트 */}
-                <p className={`text-base text-slate-800 ${textStyle}`}>
-                    {text}
-                </p>
+                {/* 할 일 텍스트 (편집 가능/불가능) */}
+                {editable && onTextChange ? (
+                    <input
+                        type="text"
+                        value={text}
+                        onChange={(e) => onTextChange(e.target.value)}
+                        className={`flex-1 bg-transparent text-base text-slate-800 ${textStyle} outline-none`}
+                        placeholder="할 일 제목"
+                    />
+                ) : (
+                    <p className={`text-base text-slate-800 ${textStyle}`}>
+                        {text}
+                    </p>
+                )}
             </div>
         </div>
     );

--- a/components/todo/TodoDetail.tsx
+++ b/components/todo/TodoDetail.tsx
@@ -5,8 +5,8 @@ import {useEffect} from "react";
 import Button from "@/components/common/Button";
 import ImageUpload from "@/components/common/ImageUpload";
 import Memo from "@/components/common/Memo";
-import Checkbox from "@/components/common/CheckBox";
 import {TodoDetailProps} from "@/lib/type";
+import Checkbox from "@/components/common/CheckBox";
 
 /**
  * 할 일 상세 페이지 컴포넌트
@@ -21,6 +21,7 @@ export default function TodoDetail({itemId}: TodoDetailProps) {
         isLoading,
         fetchTodoDetail,
         updateMemo,
+        updateName,
         toggleComplete,
         uploadTodoImage,
         saveTodo,
@@ -41,7 +42,7 @@ export default function TodoDetail({itemId}: TodoDetailProps) {
         const success = await saveTodo();
         if (success) {
             alert("할 일 내용이 수정되었습니다.");
-            router.refresh();
+            router.push("/");
         }
     };
 
@@ -61,17 +62,20 @@ export default function TodoDetail({itemId}: TodoDetailProps) {
 
     return (
         <div className="container mx-auto px-6 py-8 max-w-300">
-            {/* 제목 영역 */}
+
+            {/* 제목 */}
             <div className="mb-8">
                 <Checkbox
                     variant="detail"
                     isCompleted={todo.isCompleted}
                     text={todo.name}
                     onToggle={toggleComplete}
+                    editable={true}
+                    onTextChange={updateName}
                 />
             </div>
 
-            {/* 이미지 + 메모 영역 */}
+            {/* 이미지 + 메모 */}
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
                 <ImageUpload
                     imageUrl={todo.imageUrl}
@@ -84,7 +88,7 @@ export default function TodoDetail({itemId}: TodoDetailProps) {
                 />
             </div>
 
-            {/* 버튼 영역 */}
+            {/* 버튼 */}
             <div className="flex justify-center lg:justify-end gap-4">
                 <Button
                     variant="complete"

--- a/hooks/useTodoDetail.ts
+++ b/hooks/useTodoDetail.ts
@@ -40,6 +40,11 @@ export default function useTodoDetails(itemId: number) {
         }
     }, []);
 
+    // 제목 업데이트
+    const updateName = useCallback((name: string) => {
+        setTodo((prev) => prev ? {...prev, name} : null);
+    }, []);
+
     // 메모 업데이트
     const updateMemo = useCallback((memo: string) => {
         setTodo((prev) => prev ? {...prev, memo} : null);
@@ -57,8 +62,8 @@ export default function useTodoDetails(itemId: number) {
         try {
             await patchItemDetail(itemId, {
                 name: todo.name,
-                memo: todo.memo,
-                imageUrl: todo.imageUrl,
+                memo: todo.memo || undefined,
+                imageUrl: todo.imageUrl || undefined,
                 isCompleted: todo.isCompleted
             });
             return true;
@@ -86,6 +91,7 @@ export default function useTodoDetails(itemId: number) {
         isLoading,
         fetchTodoDetail,
         uploadTodoImage,
+        updateName,
         updateMemo,
         toggleComplete,
         saveTodo,

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -101,6 +101,8 @@ export interface CheckboxProps {
     text: string;
     onToggle: () => void;
     variant?: CheckboxVariant;
+    editable?: boolean;
+    onTextChange?: (text: string) => void;
 }
 
 export type ButtonVariant = "add" | "delete" | "complete";


### PR DESCRIPTION
## 🛠️ 설명 (Description)

Todo 상세 페이지에서 제목 편집 UX 개선을 중심으로 기능을 보완했습니다.

`CheckBox` 컴포넌트에서 편집 모드를 추가, 상세 페이지에서 제목을 직접 수정할 수 있또록 개선했습니다.
이에 맞춰 `useTodoDetail` 훅에 제목만 업데이트하는 `updateName` 함수를 추가하고, 저장 로직을 정리했습니다.

또한 저장 시 불필요한 null 값이 API로 전달되지 않도록, `imageUrl`, `memo` 값을 undefined로 변환 처리했으며, 수정 완료 후 메인 페이지로 이동하도록 흐름을 개선했습니다.

## 📝 변경 사항 요약 (Summary)
	
- `Checkbox` 컴포넌트에 편집 모드 추가
  - `editable`, `onTextChange` props 추가
  - `detail variant`에서 제목 편집 가능
- `useTodoDetail` 훅에 `updateName` 함수 추가
- `TodoDetail`에서 제목 편집 기능 연동
- `saveTodo` 함수 개선
  - `imageUrl`, `memo` null → undefined 처리
  - 수정 완료 후 메인 페이지로 이동

## 🔗 관련 이슈 (Related Issues)

- Closed #7 
- Related #None